### PR TITLE
auth: added user authentication and authorization.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 /.vagrant
 /node_modules
 package-lock.json
+.env
+scratchpad*

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,7 @@ services:
     command: npm run dev
     ports:
       - 3000:3000
+    env_file: .env
   database:
     image: dannyben/alpine-mongo:latest
     ports:

--- a/index.js
+++ b/index.js
@@ -1,12 +1,35 @@
 const express = require("express");
 const app = express();
+const mongoose = require("mongoose");
+
+app.use(express.urlencoded({ extended: true }));
+app.use(express.json());
+
+mongoose
+    .connect(process.env.MONGO, {
+        useNewUrlParser: true,
+        useUnifiedTopology: true,
+        useCreateIndex: true,
+        useFindAndModify: false,
+    })
+    .then(() => console.log("Connected to mongodb"))
+    .catch((err) => console.log(err));
 
 const port = 3000;
 
-app.get('/', (req, res) => {
-    res.send("Hello World!");
-})
+app.get("/", async (req, res) => {
+    //! Only for testing
+    try {
+        const users = await require("./services/UserService").getAllUsers();
+        res.status(200).json(users);
+    } catch (error) {
+        res.status(400).json(error);
+    }
+});
+
+app.use("/api/auth/", require("./routes/auth"));
+app.use("/api/users/", require("./routes/user"));
 
 app.listen(port, () => {
     console.log(`Listening on port ${port}`);
-})
+});

--- a/models/Error.js
+++ b/models/Error.js
@@ -1,0 +1,9 @@
+class Error {
+    constructor(statusCode, msg) {
+        this.code = statusCode;
+        this.result = "FAILURE";
+        this.msg = msg;
+    }
+}
+
+module.exports = Error;

--- a/models/User.js
+++ b/models/User.js
@@ -1,0 +1,34 @@
+const mongoose = require("mongoose");
+
+const UserSchema = new mongoose.Schema({
+    zprn: {
+        type: Number,
+        required: true,
+        unique: true,
+    },
+    firstName: {
+        type: String,
+        required: true,
+    },
+    lastName: {
+        type: String,
+        required: true,
+    },
+    password: {
+        type: String,
+        required: true,
+    },
+    department: {
+        type: String,
+        required: true,
+    },
+    role: {
+        type: String,
+        required: true,
+    },
+    disabled: {
+        type: Boolean,
+    },
+});
+
+module.exports = mongoose.model("User", UserSchema);

--- a/package.json
+++ b/package.json
@@ -11,6 +11,10 @@
   "license": "ISC",
   "dependencies": {
     "express": "^4.17.1",
-    "nodemon": "^2.0.3"
+    "nodemon": "^2.0.3",
+    "mongoose": "5.9.10",
+    "bcryptjs": "2.4.3",
+    "jsonwebtoken": "8.5.1",
+    "@hapi/joi": "17.1.1"
   }
 }

--- a/routes/auth.js
+++ b/routes/auth.js
@@ -1,0 +1,66 @@
+const router = require("express").Router();
+const bcrypt = require("bcryptjs");
+const jwtService = require("../services/JwtService");
+const Error = require("../models/Error");
+const Joi = require("@hapi/joi");
+
+const userService = require("../services/UserService");
+
+router.post("/login", async (req, res) => {
+    try {
+        const { zprn, password } = req.body;
+        const { error } = validateCredentials(zprn, password);
+        if (error !== undefined) {
+            res.status(401).send(
+                new Error("BAD_REQUEST", error.details[0].message)
+            );
+        } else {
+            const user = await userService.getUser(Number(zprn));
+            if (user == null) {
+                res.status(401).send(
+                    new Error("BAD_REQUEST", "No user found.")
+                );
+            } else {
+                const match = bcrypt.compareSync(password, user.password);
+                if (match) {
+                    let token = null;
+                    try {
+                        token = jwtService.sign({
+                            userID: user.zprn,
+                            department: user.department,
+                        });
+                    } catch (error) {
+                        res.status(403).send(
+                            new Error("FORBIDDEN", error.message)
+                        );
+                        return;
+                    }
+                    res.status(200).json({
+                        code: "OK",
+                        result: "SUCCESS",
+                        token: token,
+                    });
+                } else {
+                    res.status(403).send(
+                        new Error("FORBIDDEN", "Password incorrect!")
+                    );
+                }
+            }
+        }
+    } catch (error) {
+        res.status(500).send(new Error("INTERNAL_SERVER_ERROR", error.message));
+    }
+});
+
+/*
+ * VALIDATION FUNCTIONS
+ */
+function validateCredentials(zprn, password) {
+    const schema = Joi.object({
+        zprn: Joi.string().required().length(7).regex(/^\d+$/),
+        password: Joi.string().required().min(6),
+    });
+    return schema.validate({ zprn: zprn, password: password });
+}
+
+module.exports = router;

--- a/routes/user.js
+++ b/routes/user.js
@@ -1,0 +1,280 @@
+const router = require("express").Router();
+const bcrypt = require("bcryptjs");
+const Error = require("../models/Error");
+const Joi = require("@hapi/joi");
+const jwtService = require("../services/JwtService");
+
+const userService = require("../services/UserService");
+
+/*
+ * GET USER INFO
+ * [Only loggedIn user can see their info. The userID of loggedIn user is stored in the JWT token itself]
+ */
+router.get("/", async (req, res) => {
+    let userID = null;
+    try {
+        userID = jwtService.verify(req.headers["authorization"]).userID;
+    } catch (error) {
+        res.status(403).send(new Error("FORBIDDEN", error.message));
+        return;
+    }
+    try {
+        const user = await userService.getUser(userID);
+        if (user == null) {
+            res.status(401).json(new Error("BAD_REQUEST", "No user found!"));
+        } else {
+            res.status(200).json({
+                code: "OK",
+                result: "SUCCESS",
+                user: {
+                    zprn: user.zprn,
+                    firstName: user.firstName,
+                    lastName: user.lastName,
+                    department: user.department,
+                },
+            });
+        }
+    } catch (error) {
+        res.status(500).send(new Error("INTERNAL_SERVER_ERROR", error.message));
+    }
+});
+
+/*
+ * ADD NEW USER
+ */
+router.post("/add", async (req, res) => {
+    let { zprn, firstName, lastName, password, department, role } = req.body;
+    try {
+        const { error } = validateData(
+            zprn,
+            firstName,
+            lastName,
+            password,
+            department,
+            role
+        );
+        if (error != undefined) {
+            res.status(401).send(
+                new Error("BAD_REQUEST", error.details[0].message)
+            );
+        } else {
+            const salt = bcrypt.genSaltSync(10);
+            const hashedPassword = bcrypt.hashSync(password, salt);
+            await userService.addUser(
+                zprn,
+                firstName,
+                lastName,
+                hashedPassword,
+                department,
+                role
+            );
+            res.status(201).json({
+                code: "CREATED",
+                msg: "User added!",
+                result: "SUCCESS",
+            });
+        }
+    } catch (error) {
+        res.status(500).send(new Error("INTERNAL_SERVER_ERROR", error.message));
+    }
+});
+
+/*
+ * USER: UPDATE PASSWORD
+ */
+router.patch("/update/password", async (req, res) => {
+    let userID = null;
+    try {
+        userID = jwtService.verify(req.headers["authorization"]).userID;
+    } catch (error) {
+        res.status(403).send(new Error("FORBIDDEN", error.message));
+        return;
+    }
+    try {
+        const { oldPassword, newPassword } = req.body;
+        const { error } = validatePassword(oldPassword, newPassword);
+        if (error !== undefined) {
+            res.status(401).send(
+                new Error("BAD_REQUEST", error.details[0].message)
+            );
+        } else {
+            if (oldPassword === newPassword) {
+                res.status(401).send(
+                    new Error(
+                        "BAD_REQUEST",
+                        "New password should be different from previous password."
+                    )
+                );
+                return;
+            }
+            try {
+                const user = await userService.getUser(userID);
+                if (user == null) {
+                    res.status(401).send(
+                        new Error("BAD_REQUEST", "No user found.")
+                    );
+                } else {
+                    const match = bcrypt.compareSync(
+                        oldPassword,
+                        user.password
+                    );
+                    if (match) {
+                        const hashedPassword = bcrypt.hashSync(newPassword, 10);
+                        await userService.updateUser({
+                            zprn: userID,
+                            password: hashedPassword,
+                        });
+                        res.status(200).json({
+                            code: "OK",
+                            result: "SUCCESS",
+                            msg: "Password updated!",
+                        });
+                    } else {
+                        res.status(401).send(
+                            new Error("BAD_REQUEST", "Incorrect Password")
+                        );
+                    }
+                }
+            } catch (err) {
+                res.status(401).send(new Error("BAD_REQUEST", err.message));
+            }
+        }
+    } catch (error) {
+        res.status(500).send(new Error("INTERNAL_SERVER_ERROR", error.message));
+    }
+});
+
+/*
+ * USER: UPDATE PROFILE DETAILS
+ * [firstName,lastName & department only]
+ */
+router.post("/update/profile", async (req, res) => {
+    let userID = null;
+    try {
+        userID = jwtService.verify(req.headers["authorization"]).userID;
+    } catch (error) {
+        res.status(403).send(new Error("FORBIDDEN", error.message));
+        return;
+    }
+    try {
+        if (JSON.stringify(req.body) === "{}") {
+            res.status(401).send(
+                new Error("BAD_REQUEST", "Insufficient data.")
+            );
+        } else {
+            const { firstName, lastName, department } = req.body;
+            await userService.updateUser({
+                zprn: userID,
+                firstName: firstName,
+                lastName: lastName,
+                department: department,
+            });
+            res.status(200).json({
+                code: "OK",
+                result: "SUCCESS",
+                msg: "User updated!",
+            });
+        }
+    } catch (error) {
+        res.status(500).send(new Error("INTERNAL_SERVER_ERROR", error.message));
+    }
+});
+/*
+ * AUTHORITY: UPDATE USER DETAILS [ALL]
+ */
+router.post("/update/details/:ID", async (req, res) => {
+    try {
+        const userID = jwtService.verify(req.headers["authorization"]).userID;
+    } catch (error) {
+        res.status(403).send(new Error("FORBIDDEN", error.message));
+        return;
+    }
+    try {
+        if (JSON.stringify(req.body) === "{}") {
+            res.status(401).send(
+                new Error("BAD_REQUEST", "Required fields not provided")
+            );
+        } else {
+            const {
+                firstName,
+                lastName,
+                password,
+                department,
+                role,
+            } = req.body;
+            const hashedPassword =
+                password != undefined
+                    ? bcrypt.hashSync(password, 10)
+                    : password;
+            await userService.updateUser({
+                zprn: Number(req.params.ID),
+                firstName: firstName,
+                lastName: lastName,
+                password: hashedPassword,
+                department: department,
+                role: role,
+            });
+            res.status(200).json({
+                code: "OK",
+                result: "SUCCESS",
+                msg: "User updated!",
+            });
+        }
+    } catch (error) {
+        res.status(500).send(new Error("INTERNAL_SERVER_ERROR", error.message));
+    }
+});
+
+router.delete("/:userID", async (req, res) => {
+    try {
+        jwtService.verify(req.headers["authorization"]);
+    } catch (error) {
+        res.status(403).send(new Error("FORBIDDEN", error.message));
+        return;
+    }
+    try {
+        const user = await userService.deleteUser(Number(req.params.userID));
+        res.status(200).json({
+            code: "OK",
+            result: "SUCCESS",
+            deleted: user,
+        });
+    } catch (error) {
+        res.status(500).send(new Error("INTERNAL_SERVER_ERROR", error.message));
+    }
+});
+
+/*
+ * VALIDATION FUNCTIONS
+ */
+
+function validateData(zprn, firstName, lastName, password, department, role) {
+    const schema = Joi.object({
+        zprn: Joi.string().required().length(7).regex(/^\d+$/),
+        firstName: Joi.string().required(),
+        lastName: Joi.string().required(),
+        password: Joi.string().required().min(6),
+        department: Joi.string().required().min(3),
+        role: Joi.string().required(),
+    });
+
+    return schema.validate({
+        zprn: zprn,
+        firstName: firstName,
+        lastName: lastName,
+        password: password,
+        department: department,
+        role: role,
+    });
+}
+
+function validatePassword(old, newPassword) {
+    const schema = Joi.object({
+        oldPassword: Joi.string().required(),
+        newPassword: Joi.string().required().min(6),
+    });
+
+    return schema.validate({ oldPassword: old, newPassword: newPassword });
+}
+
+module.exports = router;

--- a/services/JwtService.js
+++ b/services/JwtService.js
@@ -1,0 +1,34 @@
+const jwt = require("jsonwebtoken");
+
+class JwtService {
+    constructor() {}
+
+    // SIGN TOKEN
+    sign(data) {
+        if (data != null) {
+            try {
+                return jwt.sign({ ...data }, process.env.SECRET);
+            } catch (error) {
+                throw new Error(error);
+            }
+        } else {
+            throw new Error("Invalid token!");
+        }
+    }
+
+    // VERIFY TOKEN
+    verify(authHeader) {
+        if (authHeader != undefined) {
+            const token = authHeader.split(" ")[1];
+            try {
+                return jwt.verify(token, process.env.SECRET);
+            } catch (error) {
+                throw new Error(error);
+            }
+        } else {
+            throw new Error("Invalid token!");
+        }
+    }
+}
+
+module.exports = new JwtService();

--- a/services/UserService.js
+++ b/services/UserService.js
@@ -1,0 +1,121 @@
+const User = require("../models/User");
+
+class UserService {
+    constructor() {}
+
+    // ADD USER
+    async addUser(zprn, firstName, lastName, password, department, role) {
+        const user = new User({
+            zprn: zprn,
+            role: role,
+            firstName: firstName,
+            lastName: lastName,
+            department: department,
+            password: password,
+            role: role,
+            disabled: false,
+        });
+        return new Promise(async (resolve, reject) => {
+            try {
+                const newUser = await user.save();
+                return resolve(newUser);
+            } catch (error) {
+                return reject(error);
+            }
+        });
+    }
+
+    // FIND ALL USERS
+    async getAllUsers() {
+        return new Promise(async (resolve, reject) => {
+            try {
+                const users = await User.find({ disabled: false });
+                return resolve(users);
+            } catch (error) {
+                return reject(error);
+            }
+        });
+    }
+
+    // FIND USER WITH ZPRN
+    async getUser(zprn) {
+        return new Promise(async (resolve, reject) => {
+            try {
+                const user = await User.findOne({
+                    zprn: zprn,
+                    disabled: false,
+                });
+                return resolve(user);
+            } catch (error) {
+                return reject(error);
+            }
+        });
+    }
+
+    // UPDATE USER
+    /*
+     * 'newUser' is the object containing updated details of the user.
+     * The fields that aren't to be updated should be left undefined
+     */
+    async updateUser(newUser) {
+        return new Promise(async (resolve, reject) => {
+            const {
+                zprn,
+                firstName,
+                lastName,
+                password,
+                department,
+                role,
+            } = newUser;
+            try {
+                const user = await User.findOne({ zprn: zprn });
+                user.firstName =
+                    firstName != undefined ? firstName : user.firstName;
+                user.lastName =
+                    lastName != undefined ? lastName : user.lastName;
+                user.password =
+                    password != undefined ? password : user.password;
+                user.department =
+                    department != undefined ? department : user.department;
+                user.role = role != undefined ? role : user.role;
+                const result = await user.save();
+                return resolve(result);
+            } catch (error) {
+                console.log(error);
+                return reject(error);
+            }
+        });
+    }
+
+    async deleteUsers() {
+        return new Promise(async (resolve, reject) => {
+            try {
+                const result = await User.deleteMany({});
+                return resolve(result.deletedCount);
+            } catch (error) {
+                return reject(error);
+            }
+        });
+    }
+
+    /* 
+    ! The deleted user still has the valid JWT token. The API can still te accessed with that token!
+      TODO: Somehow invalidate the deleted user's token(s)
+    */
+    async deleteUser(zprn) {
+        return new Promise(async (resolve, reject) => {
+            try {
+                // const result = await User.deleteOne({ zprn: zprn });
+                const user = await User.findOneAndUpdate(
+                    { zprn: zprn },
+                    { disabled: true }
+                );
+                return resolve(user);
+            } catch (error) {
+                return reject(error);
+            }
+        });
+    }
+}
+
+module.exports = new UserService();


### PR DESCRIPTION
Fixes #6 

**User authentication**

I've added user authentication and authorization with JWT. The user can send their credentials through `POST` method on `api/auth/login`. Upon successful validation of user credentials, the user is responded back with a JWT access token in JSON fomat.

The JWT token payload contains the userID and the user department.

**Format of response on successful validation:**
```
{
    "token":<token>
}
```

**Adding new user:**

New User can be added by sending the required user data in `x-www-form-urlencoded` or `JSON` format, using `POST` method on `api/users/add`. 

**Required fields:**
`zprn`         :  String - 7 characters long, containing all numbers
`firstName` :  String 
`lastName` :  String
`password` :  String - atleast 6 characters long
`department` : String - atleast 3 characters long
`role`          :  String

**Updating user password:**

User can update their password by sending the old password and new password on `api/users/update/password` for updating the password and `api/users/update/profile` for updating profile details, along with the valid JWT access token, using `POST` request. The provided old password is matched with the password in the database. Upon successful match, the new password is hashed and stored in the database.

The admin can update user details by `POST` request on `api/users/update/details/<userID>` with valid JWT token.

**Getting currently logged in user:**
The currently logged in user can get his/her info by sending a `GET` request on `api/users` with the valid JWT token.

**Response:**
```
{
    "zprn":<zprn>,
    "firstName":<firstName>,
    "lastName":<lastName>,
    "department":<department>,
}
```

**Deleting user:**

Moderator(s) can delete any user by sending `DELETE` request on `api/users/<userID>` with valid JWT token.