### PR TITLE
auth:implemented refresh token

### DIFF
--- a/models/User.js
+++ b/models/User.js
@@ -26,8 +26,12 @@ const UserSchema = new mongoose.Schema({
         type: String,
         required: true,
     },
-    disabled: {
+    isDisabled: {
         type: Boolean,
+    },
+    refreshToken: {
+        type: String,
+        unique: true,
     },
 });
 

--- a/services/JwtService.js
+++ b/services/JwtService.js
@@ -4,10 +4,12 @@ class JwtService {
     constructor() {}
 
     // SIGN TOKEN
-    sign(data) {
-        if (data != null) {
+    sign(payload) {
+        if (payload != null) {
             try {
-                return jwt.sign({ ...data }, process.env.SECRET);
+                return jwt.sign({ ...payload }, process.env.SECRET, {
+                    expiresIn: process.env.TOKEN_LIFE,
+                });
             } catch (error) {
                 throw new Error(error);
             }
@@ -22,6 +24,20 @@ class JwtService {
             const token = authHeader.split(" ")[1];
             try {
                 return jwt.verify(token, process.env.SECRET);
+            } catch (error) {
+                throw new Error(error);
+            }
+        } else {
+            throw new Error("Invalid token!");
+        }
+    }
+
+    // DECODE TOKEN
+    decode(authHeader) {
+        if (authHeader != undefined) {
+            const token = authHeader.split(" ")[1];
+            try {
+                return jwt.decode(token);
             } catch (error) {
                 throw new Error(error);
             }


### PR DESCRIPTION
Fixes #12 

In this version, I've implemented invalidation of deleted user's access token.

Now, the token provided is short-lived, as opposed to persistent in previous implementation. The token life should be specified as an environment variable, in string format as `2h`,`2d` etc. After the token has expired, it must be renewed using the refresh token provided at the time of login, by sending `POST` request on `api/auth/refresh`, with the refresh token passed as a `JSON` object, along with the expired access token as the authorization header.
```
{
    refreshToken:<refreshToken>
}
```
If the user is deleted i.e. User.isDisabled is set to `true`, no new access token is returned.

**Other changes**

**1.** The JWT token now contains the following payload:
```
{
    userID:<userID>,
    department:<department>,
    role:<role>
}
```
**2.** Changed `disabled` property of `User` to `isDisabled` for better readability.
**3.** Changed `deleteUsers()` in `UserService` to `deleteAllUsers()` for better readability. 
**4.** Changed the endpoint `api/users/update/details/<userID>` (accessible to authority only) to `api/users/update/profile/<userID>` for consistency.
**5.** Earlier implementation did not check the user-role for authority-specific endpoints, which is fixed in this.
Affected endpoints:
`api/users/update/profile/<userID>`
`api/users/delete/<userID>`