### PR TITLE
test: Setup testing framework and create test scripts.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 package-lock.json
 .env
 scratchpad*
+/.nyc_output
+/coverage

--- a/README.md
+++ b/README.md
@@ -1,36 +1,38 @@
 # issue-tracker
 
 ## Setup the dev env
+
 ### Windows
+
 1. Install [vagrant](https://www.vagrantup.com/docs/installation/) for your OS. Disable the hyper-v from [here](https://ugetfix.com/ask/how-to-disable-hyper-v-in-windows-10/).
 2. Install latest [VirtuaBox](https://www.virtualbox.org/wiki/Downloads) for your windows system. This is **required**.
 3. Install Git Bash (bundled with git) from [here](https://git-scm.com/downloads).
 4. Enable VT-x from your BIOS.
 5. Run Git Bash as administrator and run
-    ```
-    git config --global core.symlinks true
-    ```
+   ```
+   git config --global core.symlinks true
+   ```
 6. Confirm the setting
-    ```
-    git config core.symlinks
-    ```
-    If you see `true`, you can go ahead.
+   ```
+   git config core.symlinks
+   ```
+   If you see `true`, you can go ahead.
 7. Clone this repository anywhere on your PC
-    ```bash
-    git clone "https://github.com/Zeal-Student-Developers/issue-tracker.git"
-    ```
+   ```bash
+   git clone "https://github.com/Zeal-Student-Developers/issue-tracker.git"
+   ```
 8. Run the following commands
-    ```bash
-    cd issue-tracker
-    vagrant plugin install vagrant-vbguest
-    vagrant up --provider=virtualbox
-    ```
-    First time it will run, it will take some time to download and setup the vm, and then provision it. 
-    > Note: You may get *timed out* error and will probably need to run this command a several times to get it working. It's an issue with vagrant.
+   ```bash
+   cd issue-tracker
+   vagrant plugin install vagrant-vbguest
+   vagrant up --provider=virtualbox
+   ```
+   First time it will run, it will take some time to download and setup the vm, and then provision it.
+   > Note: You may get _timed out_ error and will probably need to run this command a several times to get it working. It's an issue with vagrant.
 9. Once vagrant is up and running, you need to connect to it
-    ```bash
-    vagrant ssh
-    ```
+   ```bash
+   vagrant ssh
+   ```
 10. Run the following commands to complete the provisioning which was started earlier. This will setup the volumes required for node_modules and mongodb database. Also it will setup the containers for nodejs and mongodb.
     ```
     tools/setup/setup full
@@ -39,62 +41,67 @@
 ### Linux:
 
 1. Install Docker and Docker Compose. You may need to enter your password while executing.
-    ```bash
-    sudo apt-get update
 
-    # Install Docker dependencies
-    sudo apt-get -y install apt-transport-https ca-certificates curl gnupg-agent software-properties-common
+   ```bash
+   sudo apt-get update
 
-    # Add Docker’s official GPG key:
-    curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
+   # Install Docker dependencies
+   sudo apt-get -y install apt-transport-https ca-certificates curl gnupg-agent software-properties-common
 
-    # Set the stable repo
-    sudo add-apt-repository -y \
-    "deb [arch=amd64] https://download.docker.com/linux/ubuntu \
-    $(lsb_release -cs) \
-    stable"
+   # Add Docker’s official GPG key:
+   curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
 
-    # Install docker
-    sudo apt-get update && sudo apt-get -y install docker-ce docker-ce-cli containerd.io
+   # Set the stable repo
+   sudo add-apt-repository -y \
+   "deb [arch=amd64] https://download.docker.com/linux/ubuntu \
+   $(lsb_release -cs) \
+   stable"
 
-    # Docker Compose Installation
-    sudo curl -s -L "https://github.com/docker/compose/releases/download/1.25.5/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
-    sudo chmod +x /usr/local/bin/docker-compose
+   # Install docker
+   sudo apt-get update && sudo apt-get -y install docker-ce docker-ce-cli containerd.io
 
-    # Auto start the docker service on boot
-    sudo systemctl enable docker
+   # Docker Compose Installation
+   sudo curl -s -L "https://github.com/docker/compose/releases/download/1.25.5/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
+   sudo chmod +x /usr/local/bin/docker-compose
 
-    # Add current user to docker group
-    sudo usermod -aG docker $USER
+   # Auto start the docker service on boot
+   sudo systemctl enable docker
 
-    # Make your scripts executable
-    cd YOUR_ISSUE_TRACKER_DIR
-    sudo chmod +x tools/* tools/setup/*
-    ```
-    **Reboot** your system.
+   # Add current user to docker group
+   sudo usermod -aG docker $USER
+
+   # Make your scripts executable
+   cd YOUR_ISSUE_TRACKER_DIR
+   sudo chmod +x tools/* tools/setup/*
+   ```
+
+   **Reboot** your system.
 
 2. Clone this repository anywhere on your PC
-    ```bash
-    git clone "https://github.com/Zeal-Student-Developers/issue-tracker.git"
-    ```
+   ```bash
+   git clone "https://github.com/Zeal-Student-Developers/issue-tracker.git"
+   ```
 3. Run the following commands to setup the containers. This will setup the volumes required for node_modules and mongodb database. Also it will setup the containers for nodejs and mongodb.
-    ```
-    cd issue-tracker
-    tools/setup/setup full
-    ```
+   ```
+   cd issue-tracker
+   tools/setup/setup full
+   ```
 
 ### Running the Application
 
 Once the setup is completed without errors, you are good to go and test the application. To run the nodemon server,
+
 ```
 tools/run-dev
 ```
+
 or if you want the containers to run in the background (detached),
+
 ```
 tools/run-dev -d
 ```
 
-Open your web browser and go to `localhost:3000`. If you see `Hello World!` there, then you are good to go! 
+Open your web browser and go to `localhost:3000`. If you see `Hello World!` there, then you are good to go!
 
 To develop the application simply open the repo and start making changes. These changes will be reflected in the server (as long as nodemon is running.)
 
@@ -107,25 +114,35 @@ To stop the containers, if you did `tools/run-dev` without `-d` simply press `CT
 ### Windows
 
 Whenever you want to stop working you need to `halt` the vagrant vm. This will free all the resources that vagrant was using.
+
 ```
 vagrant halt
 ```
+
 When you want to start the dev env again, you need to `up` the vagrant vm.
+
 ```
 vagrant up
 ```
+
 When you feel, that you need to restart the vm, you have to `reload` the vagrant vm.
+
 ```
 vagrant reload
 ```
+
 If you want to clear everything and delete the vagrant vm,
+
 ```
 vagrant destroy
 ```
+
 After using vagrant `reload` and `up` you need to get into the vm using
+
 ```
 vagrant ssh
 ```
+
 and then of course you need to use the `tools/run-dev` and `tools/stop-dev` to start and stop the docker containers inside the vm as well.
 
 ### Linux
@@ -134,18 +151,45 @@ Nothing special is required and using just the `tools/stop-dev` and `tools/run-d
 
 ## Known Issue
 
-* If you find *timed out* errors on Windows, you just need to retry `vagrant up` multiple times to get it working. It's an issue with vagrant.
+- If you find _timed out_ errors on Windows, you just need to retry `vagrant up` multiple times to get it working. It's an issue with vagrant.
 
-* If you find the error line
+- If you find the error line
+
 ```
 The vagrant user is unable to write to Project directory
 ```
+
 while running the vagrant up command, then you probably have some write issues. We can solve this by doing the following. You need to `cd` into your `issue-tracker` directory. After that run the following :-
+
 ```
 vagrant halt -f
 rm -rf .vagrant
 sudo chown -R 1000:$(id -g) .
 vagrant up
 ```
-Remove `sudo` if you are on *Windows*.
+
+Remove `sudo` if you are on _Windows_.
 And hopefully the error is gone and you can resume your work.
+
+## Running Tests
+
+Having isolated environments with vagrant and docker, we can easily setup unit
+and integration tests. We can provide the containers with a separate `.env` file
+for each test. As unit tests don't need database dependency, we don't have the
+`database` service in `docker-compose` running alongside it.
+
+Make sure you first update and install the dependencies by running,
+
+```
+tools/install-deps
+```
+
+To run the tests,
+
+```
+tools/run-test unit         # For unit tests
+
+tools/run-test integration  # For integration tests
+
+tools/run-test coverage     # For code coverage reports
+```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3'
+version: "3"
 services:
   dev:
     image: node:12.16.3-alpine3.9
@@ -9,13 +9,54 @@ services:
     command: npm run dev
     ports:
       - 3000:3000
+    depends_on:
+      - database
     env_file: .env
+
+  unit:
+    image: node:12.16.3-alpine3.9
+    volumes:
+      - nodemodules:/usr/src/service/node_modules
+      - .:/usr/src/service
+    working_dir: /usr/src/service
+    command: npm run test
+    ports:
+      - 3000:3000
+    env_file: .env
+
+  coverage:
+    image: node:12.16.3-alpine3.9
+    volumes:
+      - nodemodules:/usr/src/service/node_modules
+      - .:/usr/src/service
+    working_dir: /usr/src/service
+    command: npm run coverage
+    depends_on:
+      - database
+    ports:
+      - 3000:3000
+    env_file: .env
+
+  integration:
+    image: node:12.16.3-alpine3.9
+    volumes:
+      - nodemodules:/usr/src/service/node_modules
+      - .:/usr/src/service
+    working_dir: /usr/src/service
+    command: npm run test integration
+    depends_on:
+      - database
+    ports:
+      - 3000:3000
+    env_file: .env
+
   database:
     image: dannyben/alpine-mongo:latest
     ports:
       - 27017:27017
     volumes:
       - mongodatabase:/data/db
+
 volumes:
   nodemodules:
     external: true

--- a/models/Error.js
+++ b/models/Error.js
@@ -1,9 +1,9 @@
 class Error {
-    constructor(statusCode, msg) {
-        this.code = statusCode;
-        this.result = "FAILURE";
-        this.msg = msg;
-    }
+  constructor(statusCode, message) {
+    this.code = statusCode;
+    this.result = "FAILURE";
+    this.message = message;
+  }
 }
 
 module.exports = Error;

--- a/package.json
+++ b/package.json
@@ -4,19 +4,25 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
-    "dev": "nodemon index.js"
+    "test": "mocha ./test/unit/**/*.test.js",
+    "test integration": "mocha ./test/integration/**/*.test.js",
+    "coverage": "nyc --reporter=html --reporter=text --all mocha ./test/**/*.test.js",
+    "dev": "nodemon --legacy-watch index.js"
   },
   "author": "",
   "license": "ISC",
   "dependencies": {
     "express": "^4.17.1",
     "nodemon": "^2.0.3",
-    "mongoose": "5.9.10",
-    "bcryptjs": "2.4.3",
-    "jsonwebtoken": "8.5.1",
-    "@hapi/joi": "17.1.1",
-    "dotenv": "8.2.0",
-    "accesscontrol": "2.2.1"
+    "mongoose": "^5.9.10",
+    "bcryptjs": "^2.4.3",
+    "jsonwebtoken": "^8.5.1",
+    "@hapi/joi": "^17.1.1",
+    "dotenv": "^8.2.0",
+    "accesscontrol": "^2.2.1",
+    "mocha": "^8.0.1",
+    "nyc": "^15.1.0",
+    "chai": "^4.2.0",
+    "sinon": "^9.0.2"
   }
 }

--- a/routes/user.js
+++ b/routes/user.js
@@ -156,7 +156,7 @@ router.post(
         res.status(200).json({
           code: "OK",
           result: "SUCCESS",
-          msg: "User updated!",
+          message: "User updated!",
         });
       }
     } catch (error) {
@@ -252,7 +252,7 @@ router.post(
         res.status(200).json({
           code: "OK",
           result: "SUCCESS",
-          msg: "User updated!",
+          message: "User updated!",
         });
       }
     } catch (error) {

--- a/services/UserService.js
+++ b/services/UserService.js
@@ -8,19 +8,19 @@ class UserService {
 
   // ADD USER
   async addUser(zprn, firstName, lastName, password, department, role) {
-    const user = new User({
-      zprn: Number(zprn),
-      role: role,
-      firstName: firstName,
-      lastName: lastName,
-      department: department,
-      password: password,
-      role: role,
-      isDisabled: false,
-      refreshToken: randomBytes(45).toString("hex") + "." + zprn,
-    });
     return new Promise(async (resolve, reject) => {
       try {
+        const user = new User({
+          zprn: Number(zprn),
+          role: role,
+          firstName: firstName,
+          lastName: lastName,
+          department: department,
+          password: password,
+          role: role,
+          isDisabled: false,
+          refreshToken: randomBytes(45).toString("hex") + "." + zprn,
+        });
         const newUser = await user.save();
         return resolve(newUser);
       } catch (error) {
@@ -79,7 +79,6 @@ class UserService {
           return resolve(result);
         }
       } catch (error) {
-        console.log(error);
         return reject(error);
       }
     });
@@ -88,8 +87,13 @@ class UserService {
   async deleteAllUsers() {
     return new Promise(async (resolve, reject) => {
       try {
-        const result = await User.deleteMany({});
-        return resolve(result.deletedCount);
+        const result = await User.updateMany(
+          {},
+          {
+            isDisabled: true,
+          }
+        );
+        return resolve(result.nModified);
       } catch (error) {
         return reject(error);
       }

--- a/test/unit/services/JwtService.test.js
+++ b/test/unit/services/JwtService.test.js
@@ -1,0 +1,146 @@
+const chai = require("chai");
+const expect = chai.expect;
+const sinon = require("sinon");
+
+const JwtService = require("../../../services/JwtService");
+const jwt = require("jsonwebtoken");
+
+describe("JwtService", () => {
+  describe("sign()", () => {
+    let stub;
+    beforeEach(() => {
+      stub = sinon.stub(jwt, "sign");
+    });
+
+    afterEach(() => {
+      stub.restore();
+    });
+
+    it("signs non-empty payload and returns a jwt token.", () => {
+      stub.returns({});
+
+      const token = JwtService.sign({ foo: "bar" });
+
+      expect(stub.calledOnce).to.be.true;
+      expect(token).to.be.deep.equal({});
+    });
+
+    it("throws an Error if jwt.sign returns an error.", () => {
+      stub.throws();
+      let token;
+      try {
+        token = JwtService.sign({ foo: "bar" });
+      } catch (e) {}
+
+      expect(stub.calledOnce).to.be.true;
+      expect(stub).to.throw();
+      expect(token).to.be.undefined;
+    });
+
+    it("throws an Error if payload is null or undefined.", () => {
+      stub.returns({});
+      let token, error;
+      try {
+        token = JwtService.sign();
+      } catch (e) {
+        error = e;
+      }
+
+      expect(stub.called).to.be.false;
+      expect(token).to.be.undefined;
+      expect(error.message).to.eql("Invalid token!");
+    });
+  });
+
+  describe("verify()", () => {
+    let stub;
+    beforeEach(() => {
+      stub = sinon.stub(jwt, "verify");
+    });
+
+    afterEach(() => {
+      stub.restore();
+    });
+
+    it("returns an object if jwt.verify verifies and returns.", () => {
+      stub.returns({});
+
+      const token = JwtService.verify("Bearer xyz");
+
+      expect(stub.calledOnce).to.be.true;
+      expect(token).to.be.deep.equal({});
+    });
+
+    it("throws an Error if jwt.verify returns an error.", () => {
+      stub.throws();
+      let payload;
+      try {
+        payload = JwtService.verify("Bearer xyz");
+      } catch (e) {}
+
+      expect(stub.calledOnce).to.be.true;
+      expect(stub).to.throw();
+      expect(payload).to.be.undefined;
+    });
+
+    it("throws an Error if payload is undefined.", () => {
+      stub.returns({});
+      let payload, error;
+      try {
+        payload = JwtService.verify();
+      } catch (e) {
+        error = e;
+      }
+
+      expect(stub.called).to.be.false;
+      expect(payload).to.be.undefined;
+      expect(error.message).to.eql("Invalid token!");
+    });
+  });
+
+  describe("decode()", () => {
+    let stub;
+    beforeEach(() => {
+      stub = sinon.stub(jwt, "decode");
+    });
+
+    afterEach(() => {
+      stub.restore();
+    });
+
+    it("returns an object if jwt.decode decodes and returns.", () => {
+      stub.returns({});
+
+      const token = JwtService.decode("Bearer xyz");
+
+      expect(stub.calledOnce).to.be.true;
+      expect(token).to.be.deep.equal({});
+    });
+
+    it("throws an Error if jwt.decode returns an error.", () => {
+      stub.throws();
+      let payload;
+      try {
+        payload = JwtService.decode("Bearer xyz");
+      } catch (e) {}
+
+      expect(stub.calledOnce).to.be.true;
+      expect(stub).to.throw();
+      expect(payload).to.be.undefined;
+    });
+
+    it("throws an Error if payload is undefined.", () => {
+      stub.returns({});
+      let payload, error;
+      try {
+        payload = JwtService.decode();
+      } catch (e) {
+        error = e;
+      }
+
+      expect(stub.called).to.be.false;
+      expect(payload).to.be.undefined;
+      expect(error.message).to.eql("Invalid token!");
+    });
+  });
+});

--- a/test/unit/services/UserService.test.js
+++ b/test/unit/services/UserService.test.js
@@ -1,0 +1,408 @@
+const chai = require("chai");
+const expect = chai.expect;
+const sinon = require("sinon");
+
+const UserService = require("../../../services/UserService");
+const User = require("../../../models/User");
+const AccessControl = require("accesscontrol");
+
+describe("UserService", () => {
+  describe("getAllUsers()", () => {
+    let stub;
+    beforeEach(() => {
+      stub = sinon.stub(User, "find");
+    });
+
+    afterEach(() => {
+      stub.restore();
+    });
+
+    it("resolves to a list of users if User.find resolves", async () => {
+      stub.resolves({});
+
+      const users = await UserService.getAllUsers();
+
+      expect(stub.calledOnce).to.be.true;
+      expect(users).to.be.deep.equal({});
+    });
+
+    it("rejects if User.find rejects and throws an error", async () => {
+      stub.rejects(new Error("Some error"));
+
+      try {
+        const users = await UserService.getAllUsers();
+
+        expect(users).to.be.undefined;
+        expect.fail("It should fail and reject");
+      } catch (err) {
+        expect(stub.calledOnce).to.be.true;
+        expect(err.message).to.be.eql("Some error");
+      }
+    });
+  });
+
+  describe("getUser()", () => {
+    let userStub;
+
+    beforeEach(() => {
+      userStub = sinon.stub(User, "findOne");
+    });
+
+    afterEach(() => {
+      userStub.restore();
+    });
+
+    it("resolves if User.findOne resolves with data", async () => {
+      userStub.resolves({});
+      try {
+        const users = await UserService.getUser(123131);
+        expect(userStub.calledOnce).to.be.true;
+        expect(users).to.be.empty;
+      } catch (err) {
+        expect(err).to.be.undefined;
+      }
+    });
+
+    it("rejects if User.findOne rejects with an error", async () => {
+      userStub.rejects(new Error("Some Error"));
+      try {
+        const users = await UserService.getUser(12133);
+        expect(users).to.be.undefined;
+        expect.fail("It should fail and reject");
+      } catch (err) {
+        expect(userStub.calledOnce).to.be.true;
+        expect(err.message).to.be.eql("Some Error");
+      }
+    });
+  });
+
+  describe("addUser()", () => {
+    let userStub;
+    const userDoc = {
+      zprn: 1100881,
+      role: "admin",
+      firstName: "firstName",
+      lastName: "lastName",
+      department: "department",
+      password: "password",
+      isDisabled: false,
+      refreshToken: "axasda",
+    };
+
+    beforeEach(() => {
+      userStub = sinon.stub(User.prototype, "save");
+    });
+
+    afterEach(() => {
+      userStub.restore();
+    });
+
+    it("fails if a non-number zprn is passed to it", async () => {
+      try {
+        await UserService.addUser(
+          "random",
+          "firstName",
+          "lastName",
+          "password",
+          "department",
+          "role"
+        );
+      } catch (err) {
+        expect(err.message).to.be.eql(
+          'User validation failed: zprn: Cast to Number failed for value "NaN" at path "zprn"'
+        );
+      }
+    });
+
+    it("resolves and returns the same user if user.save() resolves", async () => {
+      userStub.resolves(userDoc);
+
+      try {
+        const userReturned = await UserService.addUser(
+          1100881,
+          "firstName",
+          "lastName",
+          "password",
+          "department",
+          "role"
+        );
+
+        expect(userStub.calledOnce).to.be.true;
+        expect(userReturned).to.be.eql(userDoc);
+      } catch (err) {
+        expect.fail(err);
+      }
+    });
+
+    it("rejects if user.save() rejects with an error", async () => {
+      userStub.rejects(new Error("Some Error"));
+
+      try {
+        const userReturned = await UserService.addUser(
+          1100881,
+          "firstName",
+          "lastName",
+          "password",
+          "department",
+          "role"
+        );
+      } catch (err) {
+        expect(err.message).to.be.eql("Some Error");
+      }
+    });
+  });
+
+  describe("deleteUser()", () => {
+    let userStub;
+
+    beforeEach(() => {
+      userStub = sinon.stub(User, "findOneAndUpdate");
+    });
+
+    afterEach(() => {
+      userStub.restore();
+    });
+
+    it("resolves and returns a user object if User.findOneAndUpdate resolves", async () => {
+      userStub.resolves({});
+
+      try {
+        const user = await UserService.deleteUser(112313);
+
+        expect(userStub.calledOnce).to.be.true;
+        expect(user).to.eql({});
+      } catch (err) {
+        expect.fail(err);
+      }
+    });
+
+    it("rejects if User.findOneAndUpdate rejects", async () => {
+      userStub.rejects(new Error("Some Error"));
+
+      try {
+        const user = await UserService.deleteUser(112313);
+
+        expect.fail("It Should fail and throw an error");
+      } catch (err) {
+        expect(userStub.calledOnce).to.be.true;
+        expect(err.message).to.eql("Some Error");
+      }
+    });
+  });
+
+  describe("deleteAllUsers()", () => {
+    let userStub;
+    beforeEach(() => {
+      userStub = sinon.stub(User, "updateMany");
+    });
+
+    afterEach(() => {
+      userStub.restore();
+    });
+
+    it("resolves and returns the count of deleted users if User.updateMany resolves", async () => {
+      userStub.resolves({ nModified: 5 });
+
+      try {
+        const deletedCount = await UserService.deleteAllUsers();
+
+        expect(userStub.calledOnce).to.be.true;
+        expect(deletedCount).to.eql(5);
+      } catch (err) {
+        expect.fail(err);
+      }
+    });
+
+    it("rejects if User.updateMany rejects with an Error", async () => {
+      userStub.rejects(new Error("Some Error"));
+
+      try {
+        const deletedCount = await UserService.deleteAllUsers();
+
+        expect.fail("It Should fail and throw an error");
+      } catch (err) {
+        expect(userStub.calledOnce).to.be.true;
+        expect(err.message).to.eql("Some Error");
+      }
+    });
+  });
+
+  describe("updateUser()", () => {
+    let userStub, stub;
+    const userDoc = {
+      zprn: 1100881,
+      role: "admin",
+      firstName: "firstName",
+      lastName: "lastName",
+      department: "department",
+      password: "password",
+      isDisabled: false,
+      refreshToken: "axasda",
+    };
+
+    beforeEach(() => {
+      userStub = sinon.stub(User.prototype, "save");
+      stub = sinon.stub(User, "findOne");
+    });
+
+    afterEach(() => {
+      userStub.restore();
+      stub.restore();
+    });
+
+    it("rejects if User.findOne rejects", async () => {
+      stub.rejects();
+
+      try {
+        const updatedUser = await UserService.updateUser(userDoc);
+
+        expect.fail("It should fail with an error.");
+      } catch (err) {
+        expect(stub.calledOnce).to.be.true;
+        expect(err.message).to.eql("Error");
+      }
+    });
+
+    it("rejects if User.findOne returns null", async () => {
+      stub.resolves(null);
+
+      try {
+        const updatedUser = await UserService.updateUser(userDoc);
+
+        expect.fail("It should fail with an error");
+      } catch (err) {
+        expect(stub.calledOnce).to.be.true;
+        expect(err.message).to.eql("No user found");
+      }
+    });
+
+    it("resolves and returns the updated user if user.save resolves", async () => {
+      stub.resolves({ ...userDoc, save: userStub });
+      userStub.resolves(userDoc);
+
+      try {
+        const updatedUser = await UserService.updateUser(userDoc);
+
+        expect(stub.calledOnce).to.be.true;
+        expect(userStub.calledOnce).to.be.true;
+        expect(updatedUser).to.equal(userDoc);
+      } catch (err) {
+        expect.fail(err);
+      }
+    });
+
+    it("resolves and returns the same user if parameters passed to newUser are undefined", async () => {
+      stub.resolves({ ...userDoc, save: userStub });
+      userStub.resolves(userDoc);
+
+      try {
+        const updatedUser = await UserService.updateUser({});
+
+        expect(stub.calledOnce).to.be.true;
+        expect(userStub.calledOnce).to.be.true;
+        expect(updatedUser).to.equal(userDoc);
+      } catch (err) {
+        expect.fail(err);
+      }
+    });
+
+    it("rejects if user.save rejects with an error", async () => {
+      stub.resolves({ ...userDoc, save: userStub });
+      userStub.rejects(new Error("Some error"));
+
+      try {
+        const updatedUser = await UserService.updateUser(userDoc);
+
+        expect.fail("It should fail with an error");
+      } catch (err) {
+        expect(stub.calledOnce).to.be.true;
+        expect(userStub.calledOnce).to.be.true;
+        expect(err.message).to.eql("Some error");
+      }
+    });
+  });
+
+  describe("allowIfLoggedIn()", () => {
+    let nextSpy;
+
+    beforeEach(() => {
+      nextSpy = sinon.spy();
+    });
+
+    it("returns an error if res.locals.loggedInUser is undefined", async () => {
+      const retval = await UserService.allowIfLoggedIn(
+        {},
+        {
+          locals: { loggedInUser: undefined },
+          status: sinon
+            .stub()
+            .returns({ json: sinon.stub().returns(new Error("Some Error")) }),
+        },
+        nextSpy
+      );
+
+      expect(nextSpy.callCount).to.eql(0);
+      expect(retval.message).to.eql("Some Error");
+    });
+
+    it("calls next() without any error if res.locals.loggedInUser is set", async () => {
+      await UserService.allowIfLoggedIn(
+        {},
+        { locals: { loggedInUser: "Some User" } },
+        nextSpy
+      );
+
+      expect(nextSpy.calledOnce).to.be.true;
+      expect(nextSpy.getCall(0).args).to.be.empty;
+    });
+
+    it("calls next() with an error passed to it if loggedInUser is not set", async () => {
+      await UserService.allowIfLoggedIn({}, {}, nextSpy);
+
+      expect(nextSpy.calledOnce).to.be.true;
+      expect(nextSpy.getCall(0).args[0]).to.exist;
+    });
+  });
+
+  describe("hasAccessTo()", () => {
+    let rolesStub;
+    let nextSpy;
+
+    beforeEach(() => {
+      rolesStub = sinon.stub(AccessControl.prototype, "can");
+      nextSpy = sinon.spy();
+    });
+
+    afterEach(() => {
+      rolesStub.restore();
+    });
+
+    it("calls next() without any error if role has permission granted", async () => {
+      rolesStub.returns({ updateOwn: sinon.stub().returns({ granted: true }) });
+
+      await UserService.hasAccessTo("updateOwn", "something")(
+        { user: { role: "somerole" } },
+        {},
+        nextSpy
+      );
+
+      expect(nextSpy.calledOnce).to.be.true;
+      expect(nextSpy.getCall(0).args).to.be.empty;
+    });
+
+    it("calls next with an error if role doesn't have permission granted", async () => {
+      rolesStub.returns({
+        updateOwn: sinon.stub().returns({ granted: false }),
+      });
+
+      await UserService.hasAccessTo("updateOwn", "something")(
+        { user: { role: "somerole" } },
+        {},
+        nextSpy
+      );
+
+      expect(nextSpy.calledOnce).to.be.true;
+      expect(nextSpy.getCall(0).args).to.not.be.empty;
+    });
+  });
+});

--- a/tools/run-dev
+++ b/tools/run-dev
@@ -3,9 +3,9 @@ CUR=$(dirname $(readlink -f $0))
 
 case "$1" in
     "-d")
-        docker-compose -f $CUR/../docker-compose.yml up -d
+        docker-compose -f $CUR/../docker-compose.yml up dev -d
         ;;
     *)
-        docker-compose -f $CUR/../docker-compose.yml up
+        docker-compose -f $CUR/../docker-compose.yml up dev
         ;;
 esac

--- a/tools/run-test
+++ b/tools/run-test
@@ -1,0 +1,23 @@
+#!/bin/bash
+CUR=$(dirname $(readlink -f $0))
+
+case "$1" in
+    "unit")
+        docker-compose -f $CUR/../docker-compose.yml run unit
+        ;;
+    "integration")
+        docker-compose -f $CUR/../docker-compose.yml run integration
+        ;;
+    "coverage")
+        docker-compose -f $CUR/../docker-compose.yml run coverage
+        ;;
+    *)
+        echo "Illegal Arguments
+        Usage: run-test [OPTION]
+        
+        Options:
+        unit            Run unit tests
+        integration     Run integration tests
+        coverage        Generate the code coverage reports"
+        ;;
+esac


### PR DESCRIPTION
Fixes #5 

The testing framework that has been chosen is a combination of
1. `Mocha`- as test runner
2. `Chai` - as preferred BDD assertion library
3. `Sinon` - for stubs and mocks
4. `Instanbul` - for code coverage

To create isolated environments, `tools/run-test` script has been created, 
which also simplifies our task of running tests. We need to pass the OPTION
(unit / integration / coverage). 

The `README.md` has been updated with the steps to run the tests.