### PR TITLE
removed 'url-encoded' format option from the api.

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,7 +6,6 @@ const UserService = require("./services/UserService");
 const Error = require("./models/Error");
 require("dotenv").config;
 
-app.use(express.urlencoded({ extended: true }));
 app.use(express.json());
 
 mongoose


### PR DESCRIPTION
Fixes #16 

Removed the option for passing the data in `url-encoded` format to the API.