### PR TITLE
api: added check on user exists on delete

### DIFF
--- a/routes/user.js
+++ b/routes/user.js
@@ -223,11 +223,15 @@ router.delete(
   async (req, res) => {
     try {
       const user = await userService.deleteUser(Number(req.params.userID));
-      res.status(200).json({
-        code: "OK",
-        result: "SUCCESS",
-        deleted: user,
-      });
+      if (user == null) {
+        res.status(401).send(new Error("BAD_REQUEST", "No user found."));
+      } else {
+        res.status(200).json({
+          code: "OK",
+          result: "SUCCESS",
+          deleted: user,
+        });
+      }
     } catch (error) {
       res.status(500).send(new Error("INTERNAL_SERVER_ERROR", error.message));
     }

--- a/services/UserService.js
+++ b/services/UserService.js
@@ -67,7 +67,7 @@ class UserService {
       try {
         const user = await User.findOne({ zprn: zprn });
         if (user == null) {
-          return reject(new Error("No user found"));
+          return reject(new Error("BAD_REQUEST", "No user found"));
         } else {
           user.firstName = firstName != undefined ? firstName : user.firstName;
           user.lastName = lastName != undefined ? lastName : user.lastName;


### PR DESCRIPTION
Fixes #19 

Added the check to see if the user is already deleted before deleting. If the user is not present in the database, returns an error.