### PR TITLE
auth: improved checks in JWT Service.

### DIFF
--- a/services/JwtService.js
+++ b/services/JwtService.js
@@ -3,46 +3,72 @@ const jwt = require("jsonwebtoken");
 class JwtService {
   constructor() {}
 
-  // SIGN TOKEN
+  /**
+   * Create a signed JWT token.
+   * @param payload The payload object for the JWT token.
+   * @returns Signed JWT token.
+   */
   sign(payload) {
-    if (payload != null) {
+    if (
+      payload === null ||
+      payload === undefined ||
+      Object.keys(payload).length === 0
+    ) {
+      throw new Error(
+        "Payload must be a valid object with one or more properties."
+      );
+    } else {
       try {
-        return jwt.sign({ ...payload }, process.env.SECRET, {
+        return jwt.sign(payload, process.env.SECRET, {
           expiresIn: process.env.TOKEN_LIFE,
         });
       } catch (error) {
-        throw new Error(error);
+        throw error;
       }
-    } else {
-      throw new Error("Invalid token!");
     }
   }
 
-  // VERIFY TOKEN
+  /**
+   * Verify the passed JWT token.
+   * @param authHeader The authorization header of the request containing the JWT token.
+   * @returns Decoded payload object if the JWT token is valid, else throws an error.
+   */
   verify(authHeader) {
-    if (authHeader != undefined) {
+    if (
+      authHeader === null ||
+      authHeader === undefined ||
+      !RegExp("^(Bearer )[\\w\\.]{84,}$").test(authHeader)
+    ) {
+      throw new Error("Authorization header must contain a valid JWT token.");
+    } else {
       const token = authHeader.split(" ")[1];
       try {
         return jwt.verify(token, process.env.SECRET);
       } catch (error) {
         throw error;
       }
-    } else {
-      throw new Error("Invalid token!");
     }
   }
 
-  // DECODE TOKEN
+  /**
+   * Decode the passed JWT token.
+   * @param authHeader The authorization header of the request containing the JWT token.
+   * @returns Decoded payload object passed at the time of creation of the token.
+   */
   decode(authHeader) {
-    if (authHeader != undefined) {
+    if (
+      authHeader === null ||
+      authHeader === undefined ||
+      !RegExp("^(Bearer )[\\w\\.]{84,}$").test(authHeader)
+    ) {
+      throw new Error("Authorization header must contain a valid JWT token.");
+    } else {
       const token = authHeader.split(" ")[1];
       try {
         return jwt.decode(token);
       } catch (error) {
-        throw new Error(error);
+        throw error;
       }
-    } else {
-      throw new Error("Invalid token!");
     }
   }
 }

--- a/test/unit/services/JwtService.test.js
+++ b/test/unit/services/JwtService.test.js
@@ -48,7 +48,9 @@ describe("JwtService", () => {
 
       expect(stub.called).to.be.false;
       expect(token).to.be.undefined;
-      expect(error.message).to.eql("Invalid token!");
+      expect(error.message).to.eql(
+        "Payload must be a valid object with one or more properties."
+      );
     });
   });
 
@@ -65,7 +67,9 @@ describe("JwtService", () => {
     it("returns an object if jwt.verify verifies and returns.", () => {
       stub.returns({});
 
-      const token = JwtService.verify("Bearer xyz");
+      const token = JwtService.verify(
+        "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.e30.Et9HFtf9R3GEMA0IICOfFMVXY7kkTX1wr4qCyhIf58U"
+      );
 
       expect(stub.calledOnce).to.be.true;
       expect(token).to.be.deep.equal({});
@@ -75,7 +79,9 @@ describe("JwtService", () => {
       stub.throws();
       let payload;
       try {
-        payload = JwtService.verify("Bearer xyz");
+        payload = JwtService.verify(
+          "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.e30.Et9HFtf9R3GEMA0IICOfFMVXY7kkTX1wr4qCyhIf58U"
+        );
       } catch (e) {}
 
       expect(stub.calledOnce).to.be.true;
@@ -94,7 +100,9 @@ describe("JwtService", () => {
 
       expect(stub.called).to.be.false;
       expect(payload).to.be.undefined;
-      expect(error.message).to.eql("Invalid token!");
+      expect(error.message).to.eql(
+        "Authorization header must contain a valid JWT token."
+      );
     });
   });
 
@@ -111,7 +119,9 @@ describe("JwtService", () => {
     it("returns an object if jwt.decode decodes and returns.", () => {
       stub.returns({});
 
-      const token = JwtService.decode("Bearer xyz");
+      const token = JwtService.decode(
+        "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.e30.Et9HFtf9R3GEMA0IICOfFMVXY7kkTX1wr4qCyhIf58Us"
+      );
 
       expect(stub.calledOnce).to.be.true;
       expect(token).to.be.deep.equal({});
@@ -121,7 +131,9 @@ describe("JwtService", () => {
       stub.throws();
       let payload;
       try {
-        payload = JwtService.decode("Bearer xyz");
+        payload = JwtService.decode(
+          "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.e30.Et9HFtf9R3GEMA0IICOfFMVXY7kkTX1wr4qCyhIf58U"
+        );
       } catch (e) {}
 
       expect(stub.calledOnce).to.be.true;
@@ -140,7 +152,9 @@ describe("JwtService", () => {
 
       expect(stub.called).to.be.false;
       expect(payload).to.be.undefined;
-      expect(error.message).to.eql("Invalid token!");
+      expect(error.message).to.eql(
+        "Authorization header must contain a valid JWT token."
+      );
     });
   });
 });


### PR DESCRIPTION
Fixes #24  Improved the checks on data passed to JWT service. An error is thrown if data passed is:
- `null`
- `undefined`
- An `empty` object is passed to `sign` method.
- The `Authorization header` is not of the form `Bearer <JWT token>`.